### PR TITLE
README: Remove RiceDroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@
 - **Resurrection Remix OS** | [Github](https://github.com/ResurrectionRemix) - [Web](https://resurrectionremix.com/)
 - **ResurrectionRemix-Revived** | [Github](https://github.com/ResurrectionRemix-Revived) - [Web](https://resurrectionremix.com/)
 - **Revenge OS** | [Github](https://github.com/RevengeOS) 
-- **RiceDroid** | [Github](https://github.com/RiceDroidOSS)
 - **Rising Tech Open Source Software** | [Github](https://github.com/RisingTechOSS)
 - **RohieOS** | [Github](https://github.com/RohieOS)
 - **Scorpion ROM** | [Github]( https://github.com/ScorpionRom) - [Web]( https://scorpionrom.com/)


### PR DESCRIPTION
RiceDroid and RisingOS are same and also RiceDroid sources was removed so no need to have it anymore